### PR TITLE
Add Kubernetes provisioning

### DIFF
--- a/podcast/api/api.py
+++ b/podcast/api/api.py
@@ -1,25 +1,31 @@
 from flask import Flask, request
+from flask_restful import Resource, Api
+
 import config
-import json
+from podcast.controller import controller
+from podcast.utils import random_string
+
+class CastCRUD(Resource):
+
+    def post(self):
+        json = request.get_json()
+        image = json.get('image')
+        job_id = random_string(string_length=5)
+
+        if image is not None:
+            return controller.create_job(job_id, image=image)
+        else:
+            return controller.create_job(job_id)
+
 
 app = Flask(__name__)
+api = Api(app)
 
+api.add_resource(CastCRUD, "/create/")
 
 def start():
     app.run(host=config.host, port=config.port,
             debug=config.debug)
-
-
-@app.route("/", methods=["GET"])
-def index():
-    return "Hello, Podcast!"
-
-
-@app.route("/create", methods=["POST"])
-def create_container():
-    if request.method == "POST":
-        print(json.loads(request.data))
-        return "Create, World!"
 
 
 if __name__ == "__main__":

--- a/podcast/utils/__init__.py
+++ b/podcast/utils/__init__.py
@@ -1,0 +1,7 @@
+import random
+import string
+
+def random_string(string_length=10):
+    """Generate a random string of fixed length """
+    letters = string.ascii_lowercase
+    return ''.join(random.choice(letters) for i in range(string_length))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 kubernetes==10.0.1
 Flask==1.0.2
+flask-restful==0.3.7


### PR DESCRIPTION
This PR is able to add Kubernetes provisioning for PodCast. 
- Making a POST request to /create provisions a Cast instance in the cluster and  returns the URL for Cast.
- It's also possible to pass a custom image as { "image": "image-name:tag" }, in order to provision Cast with custom environment.